### PR TITLE
Experimental live coding support a la Ndef

### DIFF
--- a/Classes/GUI/Core/UChainGUI.sc
+++ b/Classes/GUI/Core/UChainGUI.sc
@@ -39,6 +39,8 @@ UChainGUI {
 	var <>tempoMap;
 	var <>undoManager;
 	
+	var <>autoRestart = false;
+
 	*initClass {
 		
 		skin = ( 
@@ -607,6 +609,16 @@ UChainGUI {
 						};
 						this.makeViews( originalBounds );
 						this.makeCurrent;
+					if( autoRestart and: { chain.isPlaying } ) {
+						chain.release(0.5);
+						fork{
+							while( { chain.isPlaying } ) {
+								0.01.wait;
+							};
+							//currently there's no way to know the startpos so it will start from 0
+							chain.prepareAndStart()
+						}
+					}
 					}.defer(0.01);
 				};
 			})


### PR DESCRIPTION
How about  this ? It would be nicer to start the new synth as the old one is fading out, but I didn't manage to do that...

(
Udef(\test, {
    UOut.ar(0, WhiteNoise.ar() )
})
)

(
Udef(\test, {
    UOut.ar(0, SinOsc.ar() )
})
)

(
x = UChain(\test, \stereoOutput);
y = x.gui;
y.autoRestart_(true)
)
