### PR TITLE
save last target, use it for livecoding UChainGUI feature

### DIFF
--- a/Classes/Core/UChain.sc
+++ b/Classes/Core/UChain.sc
@@ -42,6 +42,8 @@ UChain : UEvent {
 	var <>ugroup;
 	var <>handlingUndo = false;
 	
+	var <lastTarget;
+
 	*initClass {
 		
 		Class.initClassTree( PresetManager );
@@ -643,6 +645,7 @@ UChain : UEvent {
 
 	prepare { |target, startPos = 0, action|
 		var cpu;
+		lastTarget = target;
 		action = MultiActionFunc( action );
 		target = target.asCollection;
 		if( target.size == 0 ) {

--- a/Classes/GUI/Core/UChainGUI.sc
+++ b/Classes/GUI/Core/UChainGUI.sc
@@ -619,7 +619,7 @@ UChainGUI {
 								0.01.wait;
 							};
 							//currently there's no way to know the startpos so it will start from 0
-							chain.prepareAndStart()
+							chain.prepareAndStart(chain.lastTarget)
 						}
 					}
 					}.defer(0.01);


### PR DESCRIPTION
How about this for saving the last used target.

test code:

```
(
Udef(\test, {
    UOut.ar(0, WhiteNoise.ar() )
})
)

(
Udef(\test, {
    UOut.ar(0, SinOsc.ar(1000) )
})
)

(
t = Group();
"using group % for target".format(t).postln;
x = UChain(\test, \stereoOutput).ugroup_(\test).prepareAndStart(t);
UChain(\sine, \stereoOutput).ugroup_(\test).prepareAndStart(t);
y = x.gui;
y.autoRestart_(true);
)
```
