### PR TITLE
UX - plays a mono Udef as if it was multichannel of n channels by playin...

### DIFF
--- a/Classes/Core/UX.sc
+++ b/Classes/Core/UX.sc
@@ -1,0 +1,127 @@
+/*
+    Unit Library
+    The Game Of Life Foundation. http://gameoflife.nl
+    Copyright 2014 Miguel Negrao, Wouter Snoei.
+
+    GameOfLife Unit Library: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    GameOfLife Unit Library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with GameOfLife Unit Library.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+UChain( UX(4, \sine), UX(4, \whiteNoise), UX(4, \lowPass), [\output, [\numChannels, 4] ]).gui
+
+UChain( [4, \sine], [4, \whiteNoise], [4, \lowPass], [\output, [\numChannels, 4] ]).gui
+
+
+Udef(\test,{
+	UIn.ar(0,2)
+})
+
+UChain( UX(4, \test) )
+
+UChain( [4, \sine], [4, \whiteNoise], [4, \lowPass], [\output, [\numChannels, 4] ]).asCompileString
+*/
+
+UX : U {
+
+	var <n;
+
+	//private
+	var counter;
+	var hasIn;
+	var hasOut;
+
+	*new { |n, def, args, mod|
+		^super.new().init2(n, def, args ? [], mod )
+	}
+
+	init { }
+
+	init2 { |nArg, in, inArgs, inMod|
+		if( nArg.isKindOf(SimpleNumber).not ) {
+			Error("UX : n must be a number ! got: %".format(nArg)).throw
+		};
+		n = nArg;
+		if( in.isKindOf( this.class.defClass ) ) {
+			def = in;
+			defName = in.name;
+			if( defName.notNil && { defName.asUdef( this.class.defClass ) == def } ) {
+				def = nil;
+			};
+		} {
+			defName = in.asSymbol;
+			def = nil;
+		};
+		if( this.def.notNil ) {
+			var ldef = this.def;
+			var keys = ldef.keys;
+			var numIns = keys.select{ |key| "u_i_ar_.*_bus".matchRegexp(key.asString)  }.size;
+			var numOuts = keys.select{ |key| "u_o_ar_.*_bus".matchRegexp(key.asString)  }.size;
+			if(numIns > 1) {
+				Error("UX - must use Udef with no more then one audio input. Udef % has % audio inputs.".format(ldef.name, numIns)).throw
+			};
+			if(numOuts > 1) {
+				Error("UX - must use Udef with no more then one audio output. Udef % has % outputs.".format(ldef.name, numOuts)).throw
+			};
+			if((numIns==0)&&(numOuts==0)) {
+				Error("UX - %: must use Udef with at least one audio input or output.".format(ldef.name)).throw
+			};
+			if( (numIns==0)&&(numOuts==0) ) {
+				Error("UX - must use Udef with at least one input or output").throw
+			};
+			hasIn = numIns > 0;
+			hasOut = numOuts > 0;
+			args = this.def.asArgsArray( inArgs ? [], this );
+		} {
+			Error("UX def '%' not found").format(in).throw;
+		};
+		preparedServers = [];
+		mod = inMod.asUModFor( this );
+
+		this.changed( \init );
+	}
+
+	getSynthArgs {
+		var nonsynthKeys = this.argSpecs.select({ |item| item.mode == \nonsynth }).collect(_.name);
+		var inOut = if(hasIn){
+			[ \u_i_ar_0_bus, this.getArg(\u_i_ar_0_bus)+counter ]
+		}++if(hasOut){
+			[ \u_o_ar_0_bus, this.getArg(\u_o_ar_0_bus)+counter]
+		};
+		^(this.args.clump(2).select({ |item|
+			var key = item[0].asString;
+			(nonsynthKeys.includes( item[0] ) ||
+			"u_i_ar_.*_bus".matchRegexp(key) ||
+			"u_o_ar_.*_bus".matchRegexp(key) ).not
+		})++inOut).flatten(1);
+	}
+
+	makeSynth { |target, startPos = 0, synthAction|
+		var synths = n.collect{ |i|
+			counter = i;
+			this.def.makeSynth( this, target, startPos, synthAction );
+		}.select(_.notNil);
+		if( synths.size == n ) {
+			this.umapPerform( \makeSynth, synths[0], startPos );
+		};
+	}
+
+	apxCPU {
+		^n*super.apxCPU
+	}
+
+	storeArgs {
+		^[n]++super.storeArgs
+	}
+
+}

--- a/Classes/Core/Unit.sc
+++ b/Classes/Core/Unit.sc
@@ -1165,7 +1165,13 @@ U : ObjectWithArgs {
 }
 
 + Array {
-	asUnit { ^U( this[0], *this[1..] ) }
+	asUnit {
+		^if( this[0].isKindOf(SimpleNumber) ) {
+			UX(this[0], this[1], *this[2..])
+		}{
+			U( this[0], *this[1..] )
+		}
+	}
 	asUnitArg { |unit, key|
 		var umapdef, umap;
 		if( ( this[0].isMemberOf( Symbol ) or: this[0].isKindOf( UMapDef ) ) && { 


### PR DESCRIPTION
UX - plays a mono Udef as if it was multichannel of n channels by playing n synths. Addresses #36.

```
UChain( UX(4, \sine), UX(4, \whiteNoise), UX(4, \lowPass), [\output, [\numChannels, 4] ]).gui

//nice syntax:
UChain( [4, \sine], [4, \whiteNoise], [4, \lowPass], [\output, [\numChannels, 4] ]).gui

//only works for mono in or mono out
Udef(\test,{
    UIn.ar(0,2)
})
UChain( UX(4, \test) )

//generates the correct compile string
UChain( [4, \sine], [4, \whiteNoise], [4, \lowPass], [\output, [\numChannels, 4] ]).asCompileString

//bundle generated:
UX(4, \sine).makeBundle(s)[0].dopostln

[ 9, u_sine, 1014, 1, 1, freq, 440, amp, 0.1, u_o_ar_0_lvl, 0, u_o_ar_0_bus, 0 ]
[ 9, u_sine, 1015, 1, 1, freq, 440, amp, 0.1, u_o_ar_0_lvl, 0, u_o_ar_0_bus, 1 ]
[ 9, u_sine, 1016, 1, 1, freq, 440, amp, 0.1, u_o_ar_0_lvl, 0, u_o_ar_0_bus, 2 ]
[ 9, u_sine, 1017, 1, 1, freq, 440, amp, 0.1, u_o_ar_0_lvl, 0, u_o_ar_0_bus, 3 ]

```

I gave it a go at implementing this. I deliberately choose to address only a specific case which is where there is a maximum one input and one output on the original Udef. This was as not to complicate matters regarding where those inputs and outputs should go. So we just take the bus number of the inputs and output and then use n-1 next consecutive buses.  This is implemented by creating n synths and then passing the correct bus number to u_i_ar_0_bus and u_o_ar_0_bus. Everything else seems to work out of the box due to the fact that the synths get added to the synth array and so all of them will get the same set messages, etc. The main disadvantage of this approach is that when going to the IO panel what you see doesn't reflect what will happen since you don't see the additional connections happening. In any case, since I wanted to address the most simple solution, I didn't want the user to be able to change where things got routed for each channel (for that they can already duplicate the udef in the gui or by code).  The mix level in the gui is still functional though and will change all channels. The main reason I didn't implement that is that for the current implementation I didn't have to touch the udef at all, while if I wanted to add the args u_o_ar_1_bus, etc in order to be able to change them in the gui then they would not be present in the specs array of the udef and I would be more work to get this working. I would say that this solution addresses the basic use case, which is "gee, I wished that lowpass could do 8 channels intead of just 1...". 

I tried to test things but I might have missed something. 
