### PR TITLE
recursive UGroups - first go at it

### DIFF
--- a/Classes/Core/UChain.sc
+++ b/Classes/Core/UChain.sc
@@ -42,6 +42,7 @@ UChain : UEvent {
 	var <>addAction = \addToHead;
 	var <>global = false;
 	var <>ugroup;
+	var <>parentUGroup;
 	var <>handlingUndo = false;
 	
 	var <lastTarget;
@@ -701,7 +702,7 @@ UChain : UEvent {
 		});
 		//cpu = this.apxCPU;
 		target = target.collect({ |tg|
-			tg = UGroup.start( ugroup, tg, this );
+			tg = UGroup.start( ugroup, tg, this, parentUGroup );
 			tg = tg.asTarget;
 			tg.server.loadBalancerAddLoad(this.apxCPU(tg));
 			tg;


### PR DESCRIPTION
I gave it a first go at implementing recursive ugroups. The difficult bit is how to maintain the syntax such that it's not needed to define the groups before hand. My current solution, which I'm not really happy with, is adding a parentUGroup variable to UChain, which sets the parent of the ugroup used. The first UChain to create a UGroup during prepare gets to decide the parent ugroup so it's not well defined what the parent UGroup will be. Also, once the parents of the UGroups are set, they are the same for the whole ULib session, unless the user changes them by manually UGroup.get(\a).parent_(\b).  
Another option is to define the ugroups explicitley, but in a way that they still get loaded from a uscore file. Perhaps something like myScore.groups_(UGroup(\a), UGroup(\b).parent_(\a).addAction_(a)) with easier syntax myScore.groups_(\a, [\b, \a, \addToTail]) 

So essentially it does work, but the interface to it is not the best yet. Do you have ideas on this ?

```
(
Udef(\in, {
    UOut.ar(0, In.ar(\bus.kr(100),1) );
});
Udef(\out, {
    Out.ar(\bus.kr(100), UIn.ar(0,1) );
});
)

(
x = UChain(\whiteNoise, [\out, [\bus, 90]]).ugroup_(\b).parentUGroup_(\a);
y = UChain([\in, [\bus, 90]], \lowPass ,[\out, [\bus, 90]]).ugroup_(\b).parentUGroup_(\a).addAction_(\addToTail);
r = UChain([\in, [\bus, 90]], \stereoOutput).ugroup_(\a).addAction_(\addToTail);
z = UScore(x,y, r);
z.prepareAndStart
)
```
