### PR TITLE
Add a separate button for unfolding a folder in UScoreEditor

### DIFF
--- a/Classes/GUI/Session/UScoreEditorGUI_TopBar.sc
+++ b/Classes/GUI/Session/UScoreEditorGUI_TopBar.sc
@@ -241,12 +241,17 @@ UScoreEditorGui_TopBar {
 			.canFocus_(false)
 			.action_({
 			    this.selectedEvents !? { |x|
-                    if( x.every(_.isFolder) ) {
-                        this.scoreEditor.unpackSelectedFolders(x)
-                    }{
-                        this.scoreEditor.folderFromEvents(x);
-                    }
+                        	this.scoreEditor.folderFromEvents(x);
 				}
+			});
+			
+		SmoothButton( header, 40@size  )
+			.states_( [[ "unfold" , Color.black, Color.clear ]] )
+			.canFocus_(false)
+			.action_({
+			    this.selectedEvents !? { |x|
+                        	this.scoreEditor.unpackSelectedFolders(x)
+			     }
 			});
 
 		header.decorator.shift(10);


### PR DESCRIPTION
Solves the issue that you cannot fold folders when there is only a single button.
