### PR TITLE
added \timeScale spec

### DIFF
--- a/UMapDefs/envelope_rel.scd
+++ b/UMapDefs/envelope_rel.scd
@@ -3,7 +3,7 @@
 
 An envelope generator of which the duration is automatically scaled to that of the event.
 
-env: an Env or EnvM object, containing time and level values. 
+env: an Env or EnvM object, containing time and level values.
 timeScale: if timeScale is 1, the duration of the envelope will become exactly that of the event, lower and higher timeScales result in a shorter and longer envelope durations.
 loop: loopmode (0: off, 1: loop, 2: alternate)
 delay: delay time before starting the env (not affected by timeScale)
@@ -20,5 +20,6 @@ UMapDef( \envelope_rel, {
 	var sig;
 	sig = UEnvGenRel.kr( \env, nil, \timeScale, \loop, \delay, \trigger );
 	UMapOut.kr(sig);
-}).mappedArgs_([ \env ])
-.category_( 'automation' )
+}).setSpec( \timeScale, [0.25,4,\exp,0,1].asSpec, \init )
+.mappedArgs_([ \env ])
+.category_( 'automation' );


### PR DESCRIPTION
envelope_rel.scd was not rescale to the event time.  I added copied the \timeScale spec from line_rel.scd.  It seems to fix the problem.